### PR TITLE
Fixed camel casing for dataattrs and dataattr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ See README.md for release description.
 ### Removed
 
 ### Changed
+- multiple patterns: changed all variables containing dataattr / dataattrs to camel case, dataAttr / dataAttrs
 
 ## [0.19.1] - 2019-05-02
 

--- a/src/atoms/buttons/button/button.json
+++ b/src/atoms/buttons/button/button.json
@@ -3,7 +3,7 @@
     "tags": ["Call to action", "functionality", "link", "click"]
   },
   "button": {
-    "dataattrs": [
+    "dataAttrs": [
       { "key": "id", "val": "lorem_ipsum" },
       { "key": "data-target", "val": "lorem1" },
       { "key": "aria-label", "val": "press me" }

--- a/src/atoms/buttons/button/button.md
+++ b/src/atoms/buttons/button/button.md
@@ -17,7 +17,7 @@ Here you can see the different uses of the variants and modifiers with buttons: 
 | \*variant | String | See the "variant options" section below  | "osg-v-default" | Name of the variant                                                |
 | modifiers | String | See the "modifier options" section below | null            | Root class to modify styles                                        |
 | color     | String | See the color options section            | "red"           | Sets state colors for text and background using global css classes |
-| dataattrs | Object | key and val                              | null            | See example in data tab                                            |
+| dataAttrs | Object | key and val                              | null            | See example in data tab                                            |
 
 (\*) mandatory
 
@@ -38,4 +38,4 @@ Here you can see the different uses of the variants and modifiers with buttons: 
 
 ### Other attributes
 
-If you want to set attributes, such as id, name, data targets etc. You can add them via the dataattrs array which accepts key, val objects and adds them to the button or the anchor.
+If you want to set attributes, such as id, name, data targets etc. You can add them via the dataAttrs array which accepts key, val objects and adds them to the button or the anchor.

--- a/src/atoms/buttons/button/button.twig
+++ b/src/atoms/buttons/button/button.twig
@@ -1,13 +1,13 @@
 {% set buttonColor = "osg-button-" ~ button.color | default('red') %}
-{% set buttonHasDataattrs = button.dataattrs is defined and button.dataattrs is not empty %}
+{% set buttonHasDataAttrs = button.dataAttrs is defined and button.dataAttrs is not empty %}
 {% set buttonVariant = button.variant | default('osg-v-default') %}
 {% set buttonModifiers = button.modifiers | default(null) %}
 
 <button
   class="osg-button {{ buttonVariant }} {{ buttonModifiers }} {{ buttonColor }}"
-  {% if buttonHasDataattrs %}
-    {% for dataattr in button.dataattrs %}
-      {{ dataattr.key }}="{{ dataattr.val }}"
+  {% if buttonHasDataAttrs %}
+    {% for dataAttr in button.dataAttrs %}
+      {{ dataAttr.key }}="{{ dataAttr.val }}"
     {% endfor %}
   {% endif %}
 >

--- a/src/atoms/forms/checkbox/checkbox.json
+++ b/src/atoms/forms/checkbox/checkbox.json
@@ -4,7 +4,7 @@
   },
   "checkbox": {
     "text": "laoreet lacinia neque",
-    "dataattrs": [
+    "dataAttrs": [
       { "key": "id", "val": "my-checkbox" },
       { "key": "name", "val": "my-checkbox" }
     ]

--- a/src/atoms/forms/checkbox/checkbox.md
+++ b/src/atoms/forms/checkbox/checkbox.md
@@ -8,7 +8,7 @@ Custom checkbox for forms
 | --------- | ------ | -------------------------- | ------- | --------------------------------------- |
 | modifiers | String | See modifier options below | null    | Root class to modify styles             |
 | \*text    | String | (text value)               | null    | Text of the checkbox                    |
-| dataattr  | Array  | key:String, val:String     | null    | Extra attributes to add to the checkbox |
+| dataAttr  | Array  | key:String, val:String     | null    | Extra attributes to add to the checkbox |
 
 (\*) mandatory
 

--- a/src/atoms/forms/checkbox/checkbox.twig
+++ b/src/atoms/forms/checkbox/checkbox.twig
@@ -1,12 +1,12 @@
-{% set hasDataattrs = checkbox.dataattrs is defined and checkbox.dataattrs is not empty %}
+{% set hasDataAttrs = checkbox.dataAttrs is defined and checkbox.dataAttrs is not empty %}
 {% set checkboxVariant = checkbox.variant | default('osg-v-default') %}
 {% set checkboxModifiers = checkbox.modifiers | default(null) %}
 
 <label class="osg-checkbox {{ checkboxVariant  }} {{ checkboxModifiers }}">
   <input type="checkbox"
-    {% if hasDataattrs %}
-      {% for dataattr in checkbox.dataattrs %}
-        {{ dataattr.key }}={{ dataattr.val }}
+    {% if hasDataAttrs %}
+      {% for dataAttr in checkbox.dataAttrs %}
+        {{ dataAttr.key }}={{ dataAttr.val }}
       {% endfor %}
     {% endif %}
   >

--- a/src/atoms/links/link_button/link_button.json
+++ b/src/atoms/links/link_button/link_button.json
@@ -3,7 +3,7 @@
     "tags": ["Call to action", "functionality", "link", "click"]
   },
   "linkButton": {
-    "dataattrs": [
+    "dataAttrs": [
       { "key": "id", "val": "lorem_ipsum" },
       { "key": "aria-label", "val": "press me" }
     ],

--- a/src/atoms/links/link_button/link_button.md
+++ b/src/atoms/links/link_button/link_button.md
@@ -19,7 +19,7 @@ Here you can see the different uses of the variants and modifiers with links: <a
 | \*variant | String | See the "variant options" section below  | "osg-v-default" | Name of the variant                                                |
 | modifiers | String | See the "modifier options" section below | null            | Root class to modify styles                                        |
 | color     | String | See the color options section            | "red"           | Sets state colors for text and background using global css classes |
-| dataattrs | Object | key and val                              | null            | See example in data tab                                            |
+| dataAttrs | Object | key and val                              | null            | See example in data tab                                            |
 | url       | String | Valid url                                | '#'             | Value of the link's href attribute                                 |
 
 (\*) mandatory
@@ -41,4 +41,4 @@ Here you can see the different uses of the variants and modifiers with links: <a
 
 ### Other attributes
 
-If you want to set attributes, such as id, name, data targets etc. You can add them via the dataattrs array which accepts key, val objects and adds them to the button or the anchor.
+If you want to set attributes, such as id, name, data targets etc. You can add them via the dataAttrs array which accepts key, val objects and adds them to the button or the anchor.

--- a/src/atoms/links/link_button/link_button.twig
+++ b/src/atoms/links/link_button/link_button.twig
@@ -1,5 +1,5 @@
 {% set linkButtonColor = "osg-link-button-" ~ linkButton.color | default('red') %}
-{% set linkButtonHasDataattrs = linkButton.dataattrs is defined and linkButton.dataattrs is not empty %}
+{% set linkButtonHasDataAttrs = linkButton.dataAttrs is defined and linkButton.dataAttrs is not empty %}
 {% set linkButtonVariant = linkButton.variant | default('osg-v-default') %}
 {% set linkButtonModifiers = linkButton.modifiers | default(null) %}
 {% set linkButtonUrl = linkButton.url | default('#') %}
@@ -7,9 +7,9 @@
 <a
   class="osg-link-button {{ linkButtonVariant }} {{ linkButtonModifiers }} {{ linkButtonColor }}"
    href="{{ linkButtonUrl }}"
-  {% if linkButtonHasDataattrs %}
-    {% for dataattr in linkButton.dataattrs %}
-      {{ dataattr.key }}="{{ dataattr.val }}"
+  {% if linkButtonHasDataAttrs %}
+    {% for dataAttr in linkButton.dataAttrs %}
+      {{ dataAttr.key }}="{{ dataAttr.val }}"
     {% endfor %}
   {% endif %}
 >

--- a/src/molecules/content_display/expand_box/expand_box-open.json
+++ b/src/molecules/content_display/expand_box/expand_box-open.json
@@ -7,6 +7,6 @@
     "color": "",
     "content": "<i class='fas fa-chevron-up'></i>",
     "modifiers": "osg-button--circle",
-    "dataattrs": [{ "key": "aria-label", "val": "expand-button" }]
+    "dataAttrs": [{ "key": "aria-label", "val": "expand-button" }]
   }
 }

--- a/src/molecules/content_display/expand_box/expand_box.json
+++ b/src/molecules/content_display/expand_box/expand_box.json
@@ -9,7 +9,7 @@
   "button": {
     "color": "",
     "modifiers": "osg-button--circle",
-    "dataattrs": [
+    "dataAttrs": [
       {
         "key": "aria-label",
         "val": "expand-button"

--- a/src/molecules/data_display/icon_link/icon_link.twig
+++ b/src/molecules/data_display/icon_link/icon_link.twig
@@ -8,7 +8,7 @@
   <a href="{{ iconLink.url }}"
     {% if iconLinkHasDataAttrs %}
       {% for dataAttr in iconLink.dataAttrs %}
-        {{dataAttr.key}}="{{dataAttr.val}}"
+        {{ dataAttr.key }}="{{ dataAttr.val }}"
       {% endfor %}
     {% endif %}
     >

--- a/src/molecules/search/search_bar/search_bar.json
+++ b/src/molecules/search/search_bar/search_bar.json
@@ -11,6 +11,6 @@
   },
   "button": {
     "modifiers": "osg-button--circle",
-    "dataattrs": [{ "key": "aria-label", "val": "Search" }]
+    "dataAttrs": [{ "key": "aria-label", "val": "Search" }]
   }
 }

--- a/src/organisms/messages/alert/alert.json
+++ b/src/organisms/messages/alert/alert.json
@@ -11,7 +11,7 @@
     },
     "buttonAriaLabel": "Amet sit ipsum",
     "closeButtonSrText": "Lukk varsel",
-    "dataattrs": [
+    "dataAttrs": [
       { "key": "id", "val": "lorem_ipsum" }
     ]
   }

--- a/src/organisms/messages/alert/alert.twig
+++ b/src/organisms/messages/alert/alert.twig
@@ -3,7 +3,7 @@
 {% set alertVariant = alert.variant|default('osg-v-default') %}
 {% set alertModifiers = alert.modifiers | default(null) %}
 {% set alertState = 'osg-alert--state-' ~ alert.state | default('default') %}
-{% set alertButtonHasDataattrs = alert.dataattrs is defined and alert.dataattrs is not empty %}
+{% set alertButtonHasDataAttrs = alert.dataAttrs is defined and alert.dataAttrs is not empty %}
 
 {% set alertCloseButtonContent %}
    {% block closeButtonContent %}
@@ -19,9 +19,9 @@
     aria-haspopup="true"
     aria-expanded="false"
     aria-label="{{ alert.buttonAriaLabel }}"
-    {% if alertButtonHasDataattrs %}
-      {% for dataattr in alert.dataattrs %}
-        {{ dataattr.key }}="{{ dataattr.val }}"
+    {% if alertButtonHasDataAttrs %}
+      {% for dataAttr in alert.dataAttrs %}
+        {{ dataAttr.key }}="{{ dataAttr.val }}"
       {% endfor %}
     {% endif %}
   >


### PR DESCRIPTION
Added missing space in {{ dataAttr.key/val }}