### PR TITLE
Update grey-light colour hex to match tile

### DIFF
--- a/src/globals/colors/palette/palette.json
+++ b/src/globals/colors/palette/palette.json
@@ -70,7 +70,7 @@
       },
       {
         "name": "grey-light",
-        "hex": "#b3f5ff"
+        "hex": "#f9f9f9"
       },
       {
         "name": "black",


### PR DESCRIPTION
I noticed that on https://styleguide.oslo.kommune.no/#/pattern/globals-colors-palette the light grey hex code does not reflect the actual colour on the background tile, here's a suggested fix for that.