### PR TITLE
Remove margin top of search input when it is not wrapped by a label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styleguide",
-  "version": "0.99.65",
+  "version": "0.99.66",
   "description": "Oslo Styleguide",
   "main": "index.js",
   "scripts": {

--- a/src/components/form/search/search.scss
+++ b/src/components/form/search/search.scss
@@ -23,12 +23,15 @@
     width: 100%;
     @extend %osg-text-size-kilo, %osg-text-size-juliett-breakpoint-large;
     @extend %osg-text-weight-medium;
+
+    & .osg-search__input {
+      @extend %osg-margin-top-2;
+    }
   }
 
   &__input {
     padding: $padding-vertical $padding-horizontal;
     @extend %osg-color-text-blue-dark;
-    @extend %osg-margin-top-2;
     border: 2px solid colors.$blue-dark;
     border-radius: 0;
     flex-grow: 1;


### PR DESCRIPTION
So the search button doesn't look deformed