### PR TITLE
Io 657 Added missing heading text in search seasons and update osg-icon class name

### DIFF
--- a/src/components/alert/alert.html
+++ b/src/components/alert/alert.html
@@ -93,7 +93,7 @@
                       <p>Important message - Friday September 12th, 13:37</p>
                     </div>
                     <div class="osg-alert__status">
-                      <span class="osg-icon osg-icons--exclamation-mark-square osg-icon--size" aria-label="Important alert" role="img"></span>
+                      <span class="osg-icon osg-icon--exclamation-mark-square osg-icon--size" aria-label="Important alert" role="img"></span>
                     </div>
                   </a>
                 </article>
@@ -141,7 +141,7 @@
                       <p>Important message - Friday September 12th, 13:37</p>
                     </div>
                     <div class="osg-alert__status">
-                      <span class="osg-icon osg-icons--exclamation-mark-square osg-icon--size" aria-label="Important alert" role="img"></span>
+                      <span class="osg-icon osg-icon--exclamation-mark-square osg-icon--size" aria-label="Important alert" role="img"></span>
                     </div>
                   </a>
                 </article>
@@ -235,7 +235,7 @@
                 <p>Important message - Friday September 12th, 13:37</p>
               </div>
               <div class="osg-alert__status">
-                <span class="osg-icon osg-icons--exclamation-mark-square osg-icon--size" aria-label="Important alert" role="img"></span>
+                <span class="osg-icon osg-icon--exclamation-mark-square osg-icon--size" aria-label="Important alert" role="img"></span>
               </div>
             </a>
           </article>

--- a/src/components/button/button.html
+++ b/src/components/button/button.html
@@ -85,10 +85,10 @@
         <div class="osg-devtools-code__box">
           <div class="osg-flex osg-flex-align-items-center">
             <div class="osg-devtools-code__box__code osg-margin-right-5">
-              <button class="osg-button osg-button--outline"><span class="osg-button__icon osg-button__icon--left osg-icons--user"></span>Icon left</button>
+              <button class="osg-button osg-button--outline"><span class="osg-button__icon osg-button__icon--left osg-icon--user"></span>Icon left</button>
             </div>
             <div class="osg-devtools-code__box__code">
-              <button class="osg-button osg-button--outline">Icon right<span class="osg-button__icon osg-button__icon--right osg-icons--user"></span></button>
+              <button class="osg-button osg-button--outline">Icon right<span class="osg-button__icon osg-button__icon--right osg-icon--user"></span></button>
             </div>
           </div>
         </div>
@@ -101,13 +101,13 @@
         <div class="osg-devtools-code__box">
           <div class="osg-flex osg-flex-align-items-center">
             <div class="osg-devtools-code__box__code osg-margin-right-5">
-              <button class="osg-button osg-button--outline osg-button--large"><span class="osg-button__icon osg-button__icon--left osg-icons--user"></span>Large</button>
+              <button class="osg-button osg-button--outline osg-button--large"><span class="osg-button__icon osg-button__icon--left osg-icon--user"></span>Large</button>
             </div>
             <div class="osg-devtools-code__box__code osg-margin-right-5">
-              <button class="osg-button osg-button--outline"><span class="osg-button__icon osg-button__icon--left osg-icons--user"></span>Medium</button>
+              <button class="osg-button osg-button--outline"><span class="osg-button__icon osg-button__icon--left osg-icon--user"></span>Medium</button>
             </div>
             <div class="osg-devtools-code__box__code">
-              <button class="osg-button osg-button--outline osg-button--small"><span class="osg-button__icon osg-button__icon--left osg-icons--user"></span>Small</button>
+              <button class="osg-button osg-button--outline osg-button--small"><span class="osg-button__icon osg-button__icon--left osg-icon--user"></span>Small</button>
             </div>
           </div>
         </div>
@@ -122,19 +122,19 @@
           <div class="osg-flex osg-flex-align-items-center">
             <div class="osg-devtools-code__box__code osg-margin-right-5">
               <button class="osg-button osg-button--icon osg-button--large">
-                <span class="osg-button__icon osg-icons--user"></span>
+                <span class="osg-button__icon osg-icon--user"></span>
                 <span class="osg-sr-only">Text</span>
               </button>
             </div>
             <div class="osg-devtools-code__box__code osg-margin-right-5">
               <button class="osg-button osg-button--icon">
-                <span class="osg-button__icon osg-icons--user"></span>
+                <span class="osg-button__icon osg-icon--user"></span>
                 <span class="osg-sr-only">Text</span>
               </button>
             </div>
             <div class="osg-devtools-code__box__code">
               <button class="osg-button osg-button--icon osg-button--small">
-                <span class="osg-button__icon osg-icons--user"></span>
+                <span class="osg-button__icon osg-icon--user"></span>
                 <span class="osg-sr-only">Text</span>
               </button>
             </div>
@@ -150,13 +150,13 @@
           <div class="osg-flex osg-flex-align-items-center">
             <div class="osg-devtools-code__box__code osg-margin-right-5">
               <button class="osg-button osg-button--circle osg-button--large osg-button--yellow">
-                <span class="osg-button__icon osg-icons--magnifying-glass-small"></span>
+                <span class="osg-button__icon osg-icon--magnifying-glass-small"></span>
                 <span class="osg-sr-only">Search</span>
               </button>
             </div>
             <div class="osg-devtools-code__box__code">
               <button class="osg-button osg-button--circle osg-button--yellow">
-                <span class="osg-button__icon osg-icons--magnifying-glass-small"></span>
+                <span class="osg-button__icon osg-icon--magnifying-glass-small"></span>
                 <span class="osg-sr-only">Search</span>
               </button>
             </div>
@@ -546,35 +546,35 @@
     <div class="osg-grid__column--12">
       <h2 class="osg-devtools-text-preset-2">Circle</h2>
       <button class="osg-button osg-button--circle osg-margin-right-15" aria-label="Previous">
-        <span class="osg-button__icon osg-icons--chevron-left"></span>
+        <span class="osg-button__icon osg-icon--chevron-left"></span>
       </button>
       <button class="osg-button osg-button--circle osg-margin-right-15" aria-label="Next">
-        <span class="osg-button__icon osg-icons--chevron-right"></span>
+        <span class="osg-button__icon osg-icon--chevron-right"></span>
       </button>
       <button class="osg-button osg-button--circle osg-margin-right-15" disabled="disabled" aria-label="Map">
-        <span class="osg-button__icon osg-icons--map"></span>
+        <span class="osg-button__icon osg-icon--map"></span>
       </button>
       <button class="osg-button osg-button--circle osg-button--hover osg-margin-right-15" aria-label="Map">
-        <span class="osg-button__icon osg-icons--map"></span>
+        <span class="osg-button__icon osg-icon--map"></span>
       </button>
       <button class="osg-button osg-button--circle osg-button--active osg-margin-right-15" aria-label="Map">
-        <span class="osg-button__icon osg-icons--map"></span>
+        <span class="osg-button__icon osg-icon--map"></span>
       </button>
     </div>
     <div class="osg-grid__column--12">
       <h2 class="osg-devtools-text-preset-2">Icons</h2>
-      <button class="osg-button osg-margin-right-15"><span class="osg-button__icon osg-button__icon--left osg-icons--map"></span>Icon left</button>
-      <button class="osg-button osg-margin-right-15">Icon right<span class="osg-button__icon osg-button__icon--right osg-icons--map"></span></button>
-      <button class="osg-button osg-button--outline osg-margin-right-15"><span class="osg-button__icon osg-button__icon--left osg-icons--map"></span>Button</button>
-      <button class="osg-button osg-button--outline osg-margin-right-15">Button<span class="osg-button__icon osg-button__icon--right osg-icons--map"></span></button>
-      <button class="osg-button osg-button--text osg-margin-right-15"><span class="osg-button__icon osg-button__icon--left osg-icons--map"></span>Button</button>
-      <button class="osg-button osg-button--text osg-margin-right-15">Button<span class="osg-button__icon osg-button__icon--right osg-icons--map"></span></button>
-      <button class="osg-button osg-margin-right-15" disabled="disabled"><span class="osg-button__icon osg-button__icon--left osg-icons--map"></span>Icon left</button>
-      <button class="osg-button osg-margin-right-15" disabled="disabled">Icon right<span class="osg-button__icon osg-button__icon--right osg-icons--map"></span></button>
-      <button class="osg-button osg-button--outline osg-margin-right-15" disabled="disabled"><span class="osg-button__icon osg-button__icon--left osg-icons--map"></span>Button</button>
-      <button class="osg-button osg-button--outline osg-margin-right-15" disabled="disabled">Button<span class="osg-button__icon osg-button__icon--right osg-icons--map"></span></button>
-      <button class="osg-button osg-button--text osg-margin-right-15" disabled="disabled"><span class="osg-button__icon osg-button__icon--left osg-icons--map"></span>Button</button>
-      <button class="osg-button osg-button--text osg-margin-right-15" disabled="disabled">Button<span class="osg-button__icon osg-button__icon--right osg-icons--map"></span></button>
+      <button class="osg-button osg-margin-right-15"><span class="osg-button__icon osg-button__icon--left osg-icon--map"></span>Icon left</button>
+      <button class="osg-button osg-margin-right-15">Icon right<span class="osg-button__icon osg-button__icon--right osg-icon--map"></span></button>
+      <button class="osg-button osg-button--outline osg-margin-right-15"><span class="osg-button__icon osg-button__icon--left osg-icon--map"></span>Button</button>
+      <button class="osg-button osg-button--outline osg-margin-right-15">Button<span class="osg-button__icon osg-button__icon--right osg-icon--map"></span></button>
+      <button class="osg-button osg-button--text osg-margin-right-15"><span class="osg-button__icon osg-button__icon--left osg-icon--map"></span>Button</button>
+      <button class="osg-button osg-button--text osg-margin-right-15">Button<span class="osg-button__icon osg-button__icon--right osg-icon--map"></span></button>
+      <button class="osg-button osg-margin-right-15" disabled="disabled"><span class="osg-button__icon osg-button__icon--left osg-icon--map"></span>Icon left</button>
+      <button class="osg-button osg-margin-right-15" disabled="disabled">Icon right<span class="osg-button__icon osg-button__icon--right osg-icon--map"></span></button>
+      <button class="osg-button osg-button--outline osg-margin-right-15" disabled="disabled"><span class="osg-button__icon osg-button__icon--left osg-icon--map"></span>Button</button>
+      <button class="osg-button osg-button--outline osg-margin-right-15" disabled="disabled">Button<span class="osg-button__icon osg-button__icon--right osg-icon--map"></span></button>
+      <button class="osg-button osg-button--text osg-margin-right-15" disabled="disabled"><span class="osg-button__icon osg-button__icon--left osg-icon--map"></span>Button</button>
+      <button class="osg-button osg-button--text osg-margin-right-15" disabled="disabled">Button<span class="osg-button__icon osg-button__icon--right osg-icon--map"></span></button>
     </div>
     <div class="osg-grid__column--12">
       <h2 class="osg-devtools-text-preset-2">Sizes</h2>
@@ -586,24 +586,24 @@
         </div>
         <div class="osg-grid__column--12 osg-grid__column--4-breakpoint-large">
           <button class="osg-button osg-button--circle osg-button--small" aria-label="Search">
-            <span class="osg-button__icon osg-icons--magnifying-glass-small"></span>
+            <span class="osg-button__icon osg-icon--magnifying-glass-small"></span>
           </button>
           <button class="osg-button osg-button--circle" aria-label="Search">
-            <span class="osg-button__icon osg-icons--magnifying-glass-small"></span>
+            <span class="osg-button__icon osg-icon--magnifying-glass-small"></span>
           </button>
           <button class="osg-button osg-button--circle osg-button--large" aria-label="Search">
-            <span class="osg-button__icon osg-icons--magnifying-glass-small"></span>
+            <span class="osg-button__icon osg-icon--magnifying-glass-small"></span>
           </button>
         </div>
         <div class="osg-grid__column--12 osg-grid__column--4-breakpoint-large">
           <button class="osg-button osg-button--icon osg-button--small" aria-label="Search">
-            <span class="osg-button__icon osg-icons--magnifying-glass-small"></span>
+            <span class="osg-button__icon osg-icon--magnifying-glass-small"></span>
           </button>
           <button class="osg-button osg-button--icon" aria-label="Search">
-            <span class="osg-button__icon osg-icons--magnifying-glass-small"></span>
+            <span class="osg-button__icon osg-icon--magnifying-glass-small"></span>
           </button>
           <button class="osg-button osg-button--icon osg-button--large" aria-label="Search">
-            <span class="osg-button__icon osg-icons--magnifying-glass-small"></span>
+            <span class="osg-button__icon osg-icon--magnifying-glass-small"></span>
           </button>
         </div>
         <div class="osg-grid__column--12">

--- a/src/components/cards/landscape_card/landscape_card.html
+++ b/src/components/cards/landscape_card/landscape_card.html
@@ -263,9 +263,9 @@
               </div>
               <div class="osg-landscape-card__content">
                 <p class="osg-text--size-kilo osg-text--size-juliett-brekapoint-large osg-text--weight-medium osg-margin-bottom-4 osg-flex osg-flex-align-items-center">
-                  <span class="osg-icon osg-icons--calendar osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light" aria-label="Date"></span>
+                  <span class="osg-icon osg-icon--calendar osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light" aria-label="Date"></span>
                   <span class="osg-margin-left-1 osg-text--weight-medium">30. august</span>
-                  <span class="osg-icon osg-icons--clock osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light osg-margin-left-4" aria-label="Time"></span>
+                  <span class="osg-icon osg-icon--clock osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light osg-margin-left-4" aria-label="Time"></span>
                   <span class="osg-margin-left-1 osg-text--weight-medium">10:00</span>
                 </p>
                 <p class="osg-landscape-card__text">It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages.</p>
@@ -278,9 +278,9 @@
             <a class="osg-landscape-card__link" href="javascript:void(0)">
               <div class="osg-landscape-card__content">
                 <p class="osg-text--size-kilo osg-text--size-juliett-brekapoint-large osg-text--weight-medium osg-margin-bottom-4 osg-flex osg-flex-align-items-center">
-                  <span class="osg-icon osg-icons--calendar osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light" aria-label="Date"></span>
+                  <span class="osg-icon osg-icon--calendar osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light" aria-label="Date"></span>
                   <span class="osg-margin-left-1 osg-text--weight-medium">30. august</span>
-                  <span class="osg-icon osg-icons--clock osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light osg-margin-left-4" aria-label="Time"></span>
+                  <span class="osg-icon osg-icon--clock osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light osg-margin-left-4" aria-label="Time"></span>
                   <span class="osg-margin-left-1 osg-text--weight-medium">10:00</span>
                 </p>
                 <p class="osg-landscape-card__text">It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages.</p>

--- a/src/components/cards/portrait_card/portrait_card.html
+++ b/src/components/cards/portrait_card/portrait_card.html
@@ -160,7 +160,7 @@
                     </div>
                   </a>
                   <div class="osg-portrait-card__actions">
-                    <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icons--calendar"></span>Add to calendar</button>
+                    <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icon--calendar"></span>Add to calendar</button>
                   </div>
                 </div>
               </div>
@@ -180,7 +180,7 @@
                     </div>
                   </a>
                   <div class="osg-portrait-card__actions">
-                    <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icons--download"></span>Download</a>
+                    <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--download"></span>Download</a>
                   </div>
                 </div>
               </div>
@@ -202,9 +202,9 @@
                   </div>
                   <div class="osg-portrait-card__content">
                     <p class="osg-text--size-lima osg-text--weight-medium osg-margin-bottom-4 osg-margin-bottom-1-breakpoint-medium osg-flex osg-flex-align-items-center">
-                      <span class="osg-icon osg-icons--calendar osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light" aria-label="Date"></span>
+                      <span class="osg-icon osg-icon--calendar osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light" aria-label="Date"></span>
                       <span class="osg-margin-left-1">30. august</span>
-                      <span class="osg-icon osg-icons--clock osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light osg-margin-left-4" aria-label="Time"></span>
+                      <span class="osg-icon osg-icon--clock osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-brekapoint-large osg-text--weight-light osg-margin-left-4" aria-label="Time"></span>
                       <span class="osg-margin-left-1">10:00</span>
                     </p>
                     <h3 class="osg-portrait-card__heading">Heading</h3>
@@ -549,7 +549,7 @@
               </div>
             </a>
             <div class="osg-portrait-card__actions">
-              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icons--calendar" aria-label="Add to calendar"></span>Add to calendar</button>
+              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icon--calendar" aria-label="Add to calendar"></span>Add to calendar</button>
             </div>
           </div>
         </div>
@@ -570,7 +570,7 @@
               </div>
             </a>
             <div class="osg-portrait-card__actions">
-              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icons--calendar" aria-label="Add to calendar"></span>Add to calendar</button>
+              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icon--calendar" aria-label="Add to calendar"></span>Add to calendar</button>
             </div>
           </div>
         </div>
@@ -586,7 +586,7 @@
               </div>
             </a>
             <div class="osg-portrait-card__actions">
-              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icons--download"></span>Download</a>
+              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--download"></span>Download</a>
             </div>
           </div>
         </div>
@@ -600,7 +600,7 @@
                 <p class="osg-portrait-card__text">Lorem ipsum</p>
               </div>
             <div class="osg-portrait-card__actions">
-              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icons--download"></span>Download</a>
+              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--download"></span>Download</a>
             </div>
           </div>
         </div>
@@ -617,9 +617,9 @@
               </div>
               <div class="osg-portrait-card__content">
                 <p class="osg-text--size-lima osg-text--weight-medium osg-margin-bottom-4 osg-margin-bottom-1-breakpoint-medium osg-flex osg-flex-align-items-center">
-                  <span class="osg-icon osg-icons--calendar osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-breakpoint-large osg-text--weight-light"></span>
+                  <span class="osg-icon osg-icon--calendar osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-breakpoint-large osg-text--weight-light"></span>
                   <span class="osg-margin-left-1">30. august</span>
-                  <span class="osg-icon osg-icons--clock osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-breakpoint-large osg-text--weight-light osg-margin-left-4"></span>
+                  <span class="osg-icon osg-icon--clock osg-text--size-hotel osg-text--size-golf-breakpoint-medium osg-text--size-delta-breakpoint-large osg-text--weight-light osg-margin-left-4"></span>
                   <span class="osg-margin-left-1">10:00</span>
                 </p>
                 <h3 class="osg-portrait-card__heading">Heading</h3>

--- a/src/components/cards/status_card/status_card.html
+++ b/src/components/cards/status_card/status_card.html
@@ -97,7 +97,7 @@
                   <p class="osg-status-card__text">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s</p>
                 </div>
                 <div class="osg-status-card__status" aria-label="Info status" role="img">
-                  <span class="osg-icon osg-icons--exclamation-mark-square"></span>
+                  <span class="osg-icon osg-icon--exclamation-mark-square"></span>
                 </div>
               </div>
               <div class="osg-status-card__footer">Footer</div>
@@ -144,7 +144,7 @@
               <a class="osg-status-card__link" href="javascript:void(0)">
                 <div class="osg-status-card__content">
                   <p class="osg-status-card__pretext osg-flex osg-flex-align-items-center">
-                    <span class="osg-icon osg-icon--space-right osg-icons--briefcase osg-text--size-india osg-text--size-hotel-breakpoint-medium osg-text--size-gold-breakpoint-large osg-text--weight-light" aria-label="briefcase" role="img"></span>
+                    <span class="osg-icon osg-icon--space-right osg-icon--briefcase osg-text--size-india osg-text--size-hotel-breakpoint-medium osg-text--size-gold-breakpoint-large osg-text--weight-light" aria-label="briefcase" role="img"></span>
                     <span>Over 2000 years old </span>
                   </p>
                   <h3 class="osg-status-card__heading">Heading</h3>
@@ -161,7 +161,7 @@
             <div class="osg-status-card osg-status-card--status osg-status-card--status--yellow">
               <div class="osg-status-card__content">
                 <p class="osg-status-card__pretext osg-flex osg-flex-align-items-center">
-                  <span class="osg-icon osg-icon--space-right osg-icons--briefcase osg-text--size-india osg-text--size-hotel-breakpoint-medium osg-text--size-gold-breakpoint-large osg-text--weight-light"></span>
+                  <span class="osg-icon osg-icon--space-right osg-icon--briefcase osg-text--size-india osg-text--size-hotel-breakpoint-medium osg-text--size-gold-breakpoint-large osg-text--weight-light"></span>
                   <span>Over 2000 years old </span>
                 </p>
                 <h3 class="osg-status-card__heading">Heading</h3>
@@ -305,7 +305,7 @@
                 <p class="osg-status-card__text">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.</p>
               </div>
               <div class="osg-status-card__status" aria-label="Info status" role="img">
-                <span class="osg-icon osg-icons--exclamation-mark-square"></span>
+                <span class="osg-icon osg-icon--exclamation-mark-square"></span>
               </div>
             </div>
             <div class="osg-status-card__footer">Footer</div>
@@ -346,7 +346,7 @@
             <a class="osg-status-card__link" href="javascript:void(0)">
               <div class="osg-status-card__content">
                 <p class="osg-status-card__pretext osg-flex osg-flex-align-items-center">
-                  <span class="osg-icon osg-icon--space-right osg-icons--briefcase osg-text--size-india osg-text--size-hotel-breakpoint-medium osg-text--size-gold-breakpoint-large osg-text--weight-light"></span>
+                  <span class="osg-icon osg-icon--space-right osg-icon--briefcase osg-text--size-india osg-text--size-hotel-breakpoint-medium osg-text--size-gold-breakpoint-large osg-text--weight-light"></span>
                   <span>Pulvinar ex sapien at neque</span>
                 </p>
                 <h3 class="osg-status-card__heading">Heading</h3>
@@ -361,7 +361,7 @@
           <div class="osg-status-card osg-status-card--status osg-status-card--status--yellow">
             <div class="osg-status-card__content">
               <p class="osg-status-card__pretext osg-flex osg-flex-align-items-center">
-                <span class="osg-icon osg-icon--space-right osg-icons--briefcase osg-text--size-india osg-text--size-hotel-breakpoint-medium osg-text--size-gold-breakpoint-large osg-text--weight-light"></span>
+                <span class="osg-icon osg-icon--space-right osg-icon--briefcase osg-text--size-india osg-text--size-hotel-breakpoint-medium osg-text--size-gold-breakpoint-large osg-text--weight-light"></span>
                 <span>Pulvinar ex sapien at neque</span>
               </p>
               <h3 class="osg-status-card__heading">Heading</h3>

--- a/src/components/contact/contactbox/contactbox.html
+++ b/src/components/contact/contactbox/contactbox.html
@@ -47,7 +47,7 @@
                     <div class="osg-contactbox__group">
                       <div class="osg-contactbox__value">
                         <p class="osg-paragraph">
-                          <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--paragraph osg-icons--facebook" aria-hidden="true"></span>Follow us on Facebook</a>
+                          <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--paragraph osg-icon--facebook" aria-hidden="true"></span>Follow us on Facebook</a>
                         </p>
                       </div>
                     </div>
@@ -102,7 +102,7 @@
           <div class="osg-contactbox__group">
             <div class="osg-contactbox__value">
               <p class="osg-paragraph">
-                <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--paragraph osg-icons--facebook" aria-hidden="true"></span>Follow us on Facebook</a>
+                <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--paragraph osg-icon--facebook" aria-hidden="true"></span>Follow us on Facebook</a>
               </p>
             </div>
           </div>
@@ -146,7 +146,7 @@
           <div class="osg-contactbox__group">
             <div class="osg-contactbox__value">
               <p class="osg-paragraph">
-                <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--paragraph osg-icons--facebook" aria-hidden="true"></span>Follow us on Facebook</a>
+                <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--paragraph osg-icon--facebook" aria-hidden="true"></span>Follow us on Facebook</a>
               </p>
             </div>
           </div>

--- a/src/components/form/input/input.html
+++ b/src/components/form/input/input.html
@@ -108,10 +108,10 @@
               <input class="osg-input__input osg-input__input--number" type="number" min="1" max="9" step="1" value="1" />
               <div class="osg-input__counter-nav">
                 <button class="osg-input__counter-nav-button osg-input__counter-nav-button--up">
-                  <span class="osg-icons--chevron-thin-up" role="img" aria-label="increase"></span>
+                  <span class="osg-icon--chevron-thin-up" role="img" aria-label="increase"></span>
                 </button>
                 <button class="osg-input__counter-nav-button osg-input__counter-nav-button--down">
-                  <span class="osg-icons--chevron-thin-down" role="img" aria-label="decrease"></span>
+                  <span class="osg-icon--chevron-thin-down" role="img" aria-label="decrease"></span>
                 </button>
               </div>
             </label>
@@ -188,7 +188,7 @@
             <label class="osg-input__label">
               Error/invalid
               <input class="osg-input__input" type="text" autocomplete="on" placeholder="Input text" aria-describedby="error-1" />
-              <span class="osg-icon osg-icons--exclamation-mark-circle"></span>
+              <span class="osg-icon osg-icon--exclamation-mark-circle"></span>
             </label>
             <div class="osg-input__error-message" id="error-1">Error message</div>
           </div>
@@ -243,10 +243,10 @@
               <input class="osg-input__input osg-input__input--number" type="number" min="1" max="9" step="1" value="1" />
               <div class="osg-input__counter-nav">
                 <button class="osg-input__counter-nav-button osg-input__counter-nav-button-up">
-                  <span class="osg-icons--chevron-thin-up" role="img" aria-label="increase"></span>
+                  <span class="osg-icon--chevron-thin-up" role="img" aria-label="increase"></span>
                 </button>
                 <button class="osg-input__counter-nav-button osg-input__counter-nav-button-down">
-                  <span class="osg-icons--chevron-thin-down" role="img" aria-label="decrease"></span>
+                  <span class="osg-icon--chevron-thin-down" role="img" aria-label="decrease"></span>
                 </button>
               </div>
             </label>

--- a/src/components/form/input/input.vue
+++ b/src/components/form/input/input.vue
@@ -3,7 +3,7 @@
     <label class="osg-input__label">
       {{ label }}
       <input class="osg-input__input" v-model="valueModel" :type="type" :name="name" :autocomplete="autocomplete" :placeholder="placeholder" :aria-describedby="conditionalErrorId" />
-      <span v-if="errorMessage" class="osg-icon osg-icons--exclamation-mark-circle"></span>
+      <span v-if="errorMessage" class="osg-icon osg-icon--exclamation-mark-circle"></span>
     </label>
     <div v-if="errorMessage" class="osg-input__error-message" :id="errorId">{{ errorMessage }}</div>
   </div>

--- a/src/components/form/search_seasons/search_seasons.html
+++ b/src/components/form/search_seasons/search_seasons.html
@@ -177,7 +177,7 @@
               v-on:itemlist-blur="event('itemlist-blur', $event)"
             >
               <template #heading=" { heading } ">
-                <h3 class="osg-text--size-golf osg-text--size-delta-breakpoint-medium osg-text--size-charlie-breakpoint-large"></h3>
+                <h3 class="osg-text--size-golf osg-text--size-delta-breakpoint-medium osg-text--size-charlie-breakpoint-large" v-html="heading"></h3>
               </template>
               <template #listitem="{ item }">
                 <span class="osg-text-size-kilo, osg-text-size-juliett-breakpoint-large osg-text-weight-light">{{ item.text }}</span>

--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -35,7 +35,7 @@
                   <div class="osg-grid__column--12">
                     <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
                       <button class="osg-button osg-none-breakpoint-medium">
-                        <span class="osg-button__icon osg-icons--crane"></span>
+                        <span class="osg-button__icon osg-icon--crane"></span>
                       </button>
                     </div>
                   </div>
@@ -58,8 +58,8 @@
                   </div>
                   <div class="osg-grid__column--7">
                     <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
-                      <button class="osg-button osg-button--outline osg-margin-right-4-breakpoint-medium osg-margin-right-8-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icons--fire-emblem"></span></button>
-                      <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icons--crane"></span></button>
+                      <button class="osg-button osg-button--outline osg-margin-right-4-breakpoint-medium osg-margin-right-8-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icon--fire-emblem"></span></button>
+                      <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icon--crane"></span></button>
                     </div>
                   </div>
                 </div>
@@ -107,7 +107,7 @@
               <div class="osg-grid__column--12">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
                   <button class="osg-button osg-none-breakpoint-medium">
-                    <span class="osg-button__icon osg-icons--crane"></span>
+                    <span class="osg-button__icon osg-icon--crane"></span>
                   </button>
                 </div>
               </div>
@@ -130,8 +130,8 @@
               </div>
               <div class="osg-grid__column--7">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
-                  <button class="osg-button osg-button--outline osg-margin-right-4-breakpoint-medium osg-margin-right-8-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icons--fire-emblem"></span></button>
-                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icons--crane"></span></button>
+                  <button class="osg-button osg-button--outline osg-margin-right-4-breakpoint-medium osg-margin-right-8-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icon--fire-emblem"></span></button>
+                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icon--crane"></span></button>
                 </div>
               </div>
             </div>

--- a/src/components/image_carousel/image_carousel.vue
+++ b/src/components/image_carousel/image_carousel.vue
@@ -3,10 +3,10 @@
     <div class="osg-carousel__content" ref="content">
       <div class="osg-carousel__navigation" v-if="images.length > 1">
         <button class="osg-button osg-button--circle osg-button--yellow" :aria-label="i18n.previousButton" @click="goToPrev">
-          <span class="osg-button__icon osg-icons--chevron-left"></span>
+          <span class="osg-button__icon osg-icon--chevron-left"></span>
         </button>
         <button class="osg-button osg-button--circle osg-button--yellow" :aria-label="i18n.nextButton" @click="goToNext">
-          <span class="osg-button__icon osg-icons--chevron-right"></span>
+          <span class="osg-button__icon osg-icon--chevron-right"></span>
         </button>
       </div>
       <div ref="track" class="osg-carousel__track" :style="{ transform: `translate(${translateX}px)`, transition: `transform ${settings.timing} ${transitionDelay}ms` }">

--- a/src/components/links/personalized_content_link/personalized_content_link.html
+++ b/src/components/links/personalized_content_link/personalized_content_link.html
@@ -39,7 +39,7 @@
             <div class="osg-grid__column--12 osg-grid__column--6-breakpoint-medium">
               <div class="osg-devtools-code__box__code">
                 <a class="osg-personalized-content-link osg-personalized-content-link--icon" href="javascript:void(0)">
-                  <span class="osg-personalized-content-link__icon osg-icons--heart" aria-hidden="true"></span>
+                  <span class="osg-personalized-content-link__icon osg-icon--heart" aria-hidden="true"></span>
                   <div>
                     <h3 class="osg-personalized-content-link__title">Title</h3>
                     <p class="osg-personalized-content-link__text">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
@@ -69,7 +69,7 @@
     <div class="osg-grid__column--12 osg-grid__column--6-breakpoint-medium">
       <h2 class="osg-devtools-text-preset-2">Icon</h2>
       <a class="osg-personalized-content-link osg-personalized-content-link--icon" href="javascript:void(0)">
-        <span class="osg-personalized-content-link__icon osg-icons--heart" aria-hidden="true"></span>
+        <span class="osg-personalized-content-link__icon osg-icon--heart" aria-hidden="true"></span>
         <div>
           <h3 class="osg-personalized-content-link__title">Title</h3>
           <p class="osg-personalized-content-link__text">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
@@ -79,7 +79,7 @@
     <div class="osg-grid__column--12 osg-grid__column--6-breakpoint-medium">
       <h2 class="osg-devtools-text-preset-2">Hover</h2>
       <a class="osg-personalized-content-link osg-personalized-content-link--icon osg-personalized-content-link--hover" href="javascript:void(0)">
-        <span class="osg-personalized-content-link__icon osg-icons--heart" aria-hidden="true"></span>
+        <span class="osg-personalized-content-link__icon osg-icon--heart" aria-hidden="true"></span>
         <div>
           <h3 class="osg-personalized-content-link__title">Title</h3>
           <p class="osg-personalized-content-link__text">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
@@ -89,7 +89,7 @@
     <div class="osg-grid__column--12 osg-grid__column--6-breakpoint-medium">
       <h2 class="osg-devtools-text-preset-2">Focus</h2>
       <a class="osg-personalized-content-link osg-personalized-content-link--icon osg-personalized-content-link--focus" href="javascript:void(0)">
-        <span class="osg-personalized-content-link__icon osg-icons--heart" aria-hidden="true"></span>
+        <span class="osg-personalized-content-link__icon osg-icon--heart" aria-hidden="true"></span>
         <div>
           <h3 class="osg-personalized-content-link__title">Title</h3>
           <p class="osg-personalized-content-link__text">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
@@ -99,7 +99,7 @@
     <div class="osg-grid__column--12 osg-grid__column--6-breakpoint-medium">
       <h2 class="osg-devtools-text-preset-2">Active</h2>
       <a class="osg-personalized-content-link osg-personalized-content-link--icon osg-personalized-content-link--active" href="javascript:void(0)">
-        <span class="osg-personalized-content-link__icon osg-icons--heart" aria-hidden="true"></span>
+        <span class="osg-personalized-content-link__icon osg-icon--heart" aria-hidden="true"></span>
         <div>
           <h3 class="osg-personalized-content-link__title">Title</h3>
           <p class="osg-personalized-content-link__text">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
@@ -109,7 +109,7 @@
     <div class="osg-grid__column--12 osg-grid__column--6-breakpoint-medium">
       <h2 class="osg-devtools-text-preset-2">Visited</h2>
       <a class="osg-personalized-content-link osg-personalized-content-link--icon osg-personalized-content-link--visited" href="javascript:void(0)">
-        <span class="osg-personalized-content-link__icon osg-icons--heart" aria-hidden="true"></span>
+        <span class="osg-personalized-content-link__icon osg-icon--heart" aria-hidden="true"></span>
         <div>
           <h3 class="osg-personalized-content-link__title">Title</h3>
           <p class="osg-personalized-content-link__text">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
@@ -119,7 +119,7 @@
     <div class="osg-grid__column--12 osg-grid__column--6-breakpoint-medium">
       <h2 class="osg-devtools-text-preset-2">Yellow border</h2>
       <a class="osg-personalized-content-link osg-personalized-content-link--icon osg-personalized-content-link--border-yellow" href="javascript:void(0)">
-        <span class="osg-personalized-content-link__icon osg-icons--heart" aria-hidden="true"></span>
+        <span class="osg-personalized-content-link__icon osg-icon--heart" aria-hidden="true"></span>
         <div>
           <h3 class="osg-personalized-content-link__title">Title</h3>
           <p class="osg-personalized-content-link__text">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
@@ -129,7 +129,7 @@
     <div class="osg-grid__column--12 osg-grid__column--6-breakpoint-medium">
       <h2 class="osg-devtools-text-preset-2">Blue icon</h2>
       <a class="osg-personalized-content-link osg-personalized-content-link--icon osg-personalized-content-link--icon-blue" href="javascript:void(0)">
-        <span class="osg-personalized-content-link__icon osg-icons--heart" aria-hidden="true"></span>
+        <span class="osg-personalized-content-link__icon osg-icon--heart" aria-hidden="true"></span>
         <div>
           <h3 class="osg-personalized-content-link__title">Title</h3>
           <p class="osg-personalized-content-link__text">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>

--- a/src/components/links/service_link/service_link.html
+++ b/src/components/links/service_link/service_link.html
@@ -18,7 +18,7 @@
           <div class="osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
             <a class="osg-service-link" href="javascript:void(0)">
               <div class="osg-service-link__icon">
-                <span class="osg-icon osg-icons--park" aria-hidden="true"></span>
+                <span class="osg-icon osg-icon--park" aria-hidden="true"></span>
               </div>
               <div class="osg-service-link__content">
                 <h4 class="osg-service-link__heading">Link</h4>
@@ -32,7 +32,7 @@
         <div class="osg-devtools-code__box">
           <a class="osg-service-link" href="javascript:void(0)">
             <div class="osg-service-link__icon">
-              <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+              <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
             </div>
             <div class="osg-service-link__content">
               <h4 class="osg-service-link__heading">Link</h4>
@@ -48,7 +48,7 @@
           <div class="osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
             <a class="osg-service-link osg-service-link--external" href="javascript:void(0)">
               <div class="osg-service-link__icon">
-                <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+                <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
               </div>
               <div class="osg-service-link__content">
                 <h4 class="osg-service-link__heading">External link</h4>
@@ -69,7 +69,7 @@
       <h2 class="osg-devtools-text-preset-2">Default</h2>
       <a class="osg-service-link" href="javascript:void(0)">
         <div class="osg-service-link__icon">
-          <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+          <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
         </div>
         <div class="osg-service-link__content">
           <h4 class="osg-service-link__heading">Title enim maximusmaximus a</h4>
@@ -81,7 +81,7 @@
       <h2 class="osg-devtools-text-preset-2">Link</h2>
       <a class="osg-service-link" href="javascript:void(0)">
         <div class="osg-service-link__icon">
-          <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+          <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
         </div>
         <div class="osg-service-link__content">
           <h4 class="osg-service-link__heading">Title enim maximusmaximus a</h4>
@@ -92,7 +92,7 @@
       <h2 class="osg-devtools-text-preset-2">External</h2>
       <a class="osg-service-link osg-service-link--external" href="javascript:void(0)">
         <div class="osg-service-link__icon">
-          <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+          <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
         </div>
         <div class="osg-service-link__content">
           <h4 class="osg-service-link__heading">Title enim maximus a</h4>
@@ -106,7 +106,7 @@
         <div class="osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
           <a class="osg-service-link osg-service-link--external osg-service-link--visited" href="javascript:void(0)">
             <div class="osg-service-link__icon">
-              <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+              <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
             </div>
             <div class="osg-service-link__content">
               <h4 class="osg-service-link__heading">Visited</h4>
@@ -117,7 +117,7 @@
         <div class="osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
           <a class="osg-service-link osg-service-link--external osg-service-link--hover" href="javascript:void(0)">
             <div class="osg-service-link__icon">
-              <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+              <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
             </div>
             <div class="osg-service-link__content">
               <h4 class="osg-service-link__heading">Hover</h4>
@@ -128,7 +128,7 @@
         <div class="osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
           <a class="osg-service-link osg-service-link--external osg-service-link--focus" href="javascript:void(0)">
             <div class="osg-service-link__icon">
-              <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+              <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
             </div>
             <div class="osg-service-link__content">
               <h4 class="osg-service-link__heading">Focus</h4>
@@ -139,7 +139,7 @@
         <div class="osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
           <a class="osg-service-link osg-service-link--external osg-service-link--active" href="javascript:void(0)">
             <div class="osg-service-link__icon">
-              <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+              <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
             </div>
             <div class="osg-service-link__content">
               <h4 class="osg-service-link__heading">Active</h4>

--- a/src/components/menu/menu.html
+++ b/src/components/menu/menu.html
@@ -19,13 +19,13 @@
                 <h2 class="osg-navbar-menu__heading">Tjenester og tilbud</h2>
                 <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
                   Tjenester og tilbud
-                  <span class="osg-icon osg-icons--plus-sign"></span>
+                  <span class="osg-icon osg-icon--plus-sign"></span>
                 </button>
                 <ul class="osg-grid osg-grid--gap osg-navbar-menu__services-list osg-navbar-menu__list-animate">
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--24h" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--24h" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Døgnåpne tjenester </span>
@@ -35,7 +35,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Koronavirus</span>
@@ -45,7 +45,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--swingset" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--swingset" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Barnehage</span>
@@ -55,7 +55,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--backpack" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--backpack" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Skole og utdanning</span>
@@ -65,7 +65,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--heart-plus" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--heart-plus" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Helse og omsorg</span>
@@ -75,7 +75,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--crane" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--crane" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Plan, bygg og eiendom</span>
@@ -85,7 +85,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--bus" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--bus" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Gate, transport og parkering </span>
@@ -95,7 +95,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--recycling" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--recycling" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Avfall og gjenvinning</span>
@@ -105,7 +105,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--park" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--park" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Natur, kultur og fritid</span>
@@ -115,7 +115,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--house-heart" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--house-heart" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Bolig og sosiale tjenester</span>
@@ -125,7 +125,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--coin-stacks" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--coin-stacks" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Skatt og næring</span>
@@ -135,7 +135,7 @@
                   <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                     <a class="osg-navbar-menu__link" href="javascript:void(0)">
                       <div class="osg-navbar-menu__link-icon">
-                        <span class="osg-icon osg-icons--water-faucet" aria-hidden="true"></span>
+                        <span class="osg-icon osg-icon--water-faucet" aria-hidden="true"></span>
                       </div>
                       <div class="osg-navbar-menu__link-content">
                         <span class="osg-navbar-menu__link-text">Vann og avløp</span>
@@ -150,7 +150,7 @@
                 <h2 class="osg-navbar-menu__heading">Dette satser vi på</h2>
                 <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
                   Dette satser vi på
-                  <span class="osg-icon osg-icons--plus-sign"></span>
+                  <span class="osg-icon osg-icon--plus-sign"></span>
                 </button>
                 <div class="osg-navbar-menu__list-animate">
                   <ul>
@@ -182,7 +182,7 @@
                 <h2 class="osg-navbar-menu__heading">Politikk og innsyn</h2>
                 <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
                   Politikk og innsyn
-                  <span class="osg-icon osg-icons--plus-sign"></span>
+                  <span class="osg-icon osg-icon--plus-sign"></span>
                 </button>
                 <div class="osg-navbar-menu__list-animate">
                   <ul>
@@ -214,7 +214,7 @@
                 <h2 class="osg-navbar-menu__heading">Finn fram i kommunen</h2>
                 <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
                   Finn fram i kommunen
-                  <span class="osg-icon osg-icons--plus-sign"></span>
+                  <span class="osg-icon osg-icon--plus-sign"></span>
                 </button>
                 <div class="osg-navbar-menu__list-animate">
                   <ul>
@@ -246,7 +246,7 @@
                 <h2 class="osg-navbar-menu__heading">Annet</h2>
                 <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
                   Annet
-                  <span class="osg-icon osg-icons--plus-sign"></span>
+                  <span class="osg-icon osg-icon--plus-sign"></span>
                 </button>
                 <div class="osg-navbar-menu__list-animate">
                   <ul>
@@ -306,14 +306,14 @@
                   <li>
                     <a class="osg-navbar-menu__link" href="javascript:void(0)" aria-label="Facebook">
                       <div class="osg-navbar-menu__link-content">
-                        <span class="osg-icon osg-icons--facebook"></span>
+                        <span class="osg-icon osg-icon--facebook"></span>
                       </div>
                     </a>
                   </li>
                   <li>
                     <a class="osg-navbar-menu__link" href="javascript:void(0)" aria-label="Twitter">
                       <div class="osg-navbar-menu__link-content">
-                        <span class="osg-icon osg-icons--twitter"></span>
+                        <span class="osg-icon osg-icon--twitter"></span>
                       </div>
                     </a>
                   </li>
@@ -343,13 +343,13 @@
             <h2 class="osg-navbar-menu__heading">Tjenester og tilbud</h2>
             <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
               Tjenester og tilbud
-              <span class="osg-icon osg-icons--plus-sign"></span>
+              <span class="osg-icon osg-icon--plus-sign"></span>
             </button>
             <ul class="osg-navbar-menu__services-list osg-navbar-menu__list-animate osg-grid osg-grid--gap">
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--24h" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--24h" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Døgnåpne tjenester </span>
@@ -359,7 +359,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Koronavirus</span>
@@ -369,7 +369,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--swingset" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--swingset" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Barnehage</span>
@@ -379,7 +379,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--backpack" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--backpack" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Skole og utdanning</span>
@@ -389,7 +389,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--heart-plus" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--heart-plus" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Helse og omsorg</span>
@@ -399,7 +399,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--crane" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--crane" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Plan, bygg og eiendom</span>
@@ -409,7 +409,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--bus" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--bus" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Gate, transport og parkering </span>
@@ -419,7 +419,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--recycling" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--recycling" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Avfall og gjenvinning</span>
@@ -429,7 +429,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--park" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--park" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Natur, kultur og fritid</span>
@@ -439,7 +439,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--house-heart" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--house-heart" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Bolig og sosiale tjenester</span>
@@ -449,7 +449,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--coin-stacks" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--coin-stacks" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Skatt og næring</span>
@@ -459,7 +459,7 @@
               <li class="osg-grid__column--12 osg-grid__column--3-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-icon">
-                    <span class="osg-icon osg-icons--water-faucet" aria-hidden="true"></span>
+                    <span class="osg-icon osg-icon--water-faucet" aria-hidden="true"></span>
                   </div>
                   <div class="osg-navbar-menu__link-content">
                     <span class="osg-navbar-menu__link-text">Vann og avløp</span>
@@ -474,7 +474,7 @@
             <h2 class="osg-navbar-menu__heading">Dette satser vi på</h2>
             <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
               Dette satser vi på
-              <span class="osg-icon osg-icons--plus-sign"></span>
+              <span class="osg-icon osg-icon--plus-sign"></span>
             </button>
             <div class="osg-navbar-menu__list-animate">
               <ul>
@@ -506,7 +506,7 @@
             <h2 class="osg-navbar-menu__heading">Politikk og innsyn</h2>
             <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
               Politikk og innsyn
-              <span class="osg-icon osg-icons--plus-sign"></span>
+              <span class="osg-icon osg-icon--plus-sign"></span>
             </button>
             <div class="osg-navbar-menu__list-animate">
               <ul>
@@ -538,7 +538,7 @@
             <h2 class="osg-navbar-menu__heading">Finn fram i kommunen</h2>
             <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
               Finn fram i kommunen
-              <span class="osg-icon osg-icons--plus-sign"></span>
+              <span class="osg-icon osg-icon--plus-sign"></span>
             </button>
             <div class="osg-navbar-menu__list-animate">
               <ul>
@@ -570,7 +570,7 @@
             <h2 class="osg-navbar-menu__heading">Annet</h2>
             <button class="osg-navbar-menu__heading-collapsable" aria-expanded="false">
               Annet
-              <span class="osg-icon osg-icons--plus-sign"></span>
+              <span class="osg-icon osg-icon--plus-sign"></span>
             </button>
             <div class="osg-navbar-menu__list-animate">
               <ul>
@@ -630,14 +630,14 @@
               <li class="osg-padding-left-13-breakpoint-medium">
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-content">
-                    <span class="osg-icon osg-icons--facebook" aria-label="Facebook"></span>
+                    <span class="osg-icon osg-icon--facebook" aria-label="Facebook"></span>
                   </div>
                 </a>
               </li>
               <li>
                 <a class="osg-navbar-menu__link" href="javascript:void(0)">
                   <div class="osg-navbar-menu__link-content">
-                    <span class="osg-icon osg-icons--twitter" aria-label="Twitter"></span>
+                    <span class="osg-icon osg-icon--twitter" aria-label="Twitter"></span>
                   </div>
                 </a>
               </li>

--- a/src/components/menu/menu.js
+++ b/src/components/menu/menu.js
@@ -82,12 +82,12 @@ function handleToggleHeading(e) {
     headingButton.setAttribute("aria-expanded", collapsibleContent.classList.contains("osg-navbar-menu__list-animate--open") ? "false" : "true");
     collapsibleContent.classList.toggle("osg-navbar-menu__list-animate--open");
 
-    if (headingButtonIconClassList.contains("osg-icons--plus-sign")) {
-      headingButtonIconClassList.remove("osg-icons--plus-sign");
-      headingButtonIconClassList.add("osg-icons--minus-sign");
+    if (headingButtonIconClassList.contains("osg-icon--plus-sign")) {
+      headingButtonIconClassList.remove("osg-icon--plus-sign");
+      headingButtonIconClassList.add("osg-icon--minus-sign");
     } else {
-      headingButtonIconClassList.add("osg-icons--plus-sign");
-      headingButtonIconClassList.remove("osg-icons--minus-sign");
+      headingButtonIconClassList.add("osg-icon--plus-sign");
+      headingButtonIconClassList.remove("osg-icon--minus-sign");
     }
   }
 

--- a/src/components/modal/modal.html
+++ b/src/components/modal/modal.html
@@ -18,7 +18,7 @@
               <div class="osg-modal__button">
                 <div></div>
                 <button class="osg-button osg-button--circle osg-button--yellow osg-modal-trigger" aria-controls="modal-1" aria-label="Close">
-                  <span class="osg-button__icon osg-icons--close"></span>
+                  <span class="osg-button__icon osg-icon--close"></span>
                 </button>
               </div>
               <div class="osg-modal__content">
@@ -80,7 +80,7 @@
           <div class="osg-modal__button">
             <div></div>
             <button class="osg-button osg-button--circle osg-button--yellow osg-modal-trigger" aria-controls="modal-2" aria-label="Close">
-              <span class="osg-button__icon osg-icons--close"></span>
+              <span class="osg-button__icon osg-icon--close"></span>
             </button>
           </div>
           <div class="osg-modal__content">

--- a/src/components/toc/toc.html
+++ b/src/components/toc/toc.html
@@ -6,9 +6,9 @@
       <div class="osg-devtools-code">
         <div class="osg-devtools-code__box">
           <div class="osg-toc">
-            <div class="osg-toc__item"><span class="osg-toc__icon osg-icons--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
-            <div class="osg-toc__item"><span class="osg-toc__icon osg-icons--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
-            <div class="osg-toc__item"><span class="osg-toc__icon osg-icons--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
+            <div class="osg-toc__item"><span class="osg-toc__icon osg-icon--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
+            <div class="osg-toc__item"><span class="osg-toc__icon osg-icon--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
+            <div class="osg-toc__item"><span class="osg-toc__icon osg-icon--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
           </div>
         </div>
       </div>
@@ -22,9 +22,9 @@
     <div class="osg-grid__column--12">
       <h2 class="osg-devtools-text-preset-2">Default</h2>
       <div class="osg-toc">
-        <div class="osg-toc__item"><span class="osg-toc__icon osg-icons--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
-        <div class="osg-toc__item"><span class="osg-toc__icon osg-icons--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
-        <div class="osg-toc__item"><span class="osg-toc__icon osg-icons--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
+        <div class="osg-toc__item"><span class="osg-toc__icon osg-icon--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
+        <div class="osg-toc__item"><span class="osg-toc__icon osg-icon--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
+        <div class="osg-toc__item"><span class="osg-toc__icon osg-icon--arrow" aria-hidden="true"></span><a href="javascript:void(0)" class="osg-toc__link">Link to header</a></div>
       </div>
     </div>
   </div>

--- a/src/general/icons/icons.scss
+++ b/src/general/icons/icons.scss
@@ -90,7 +90,7 @@ $sizes: (
   ),
 );
 
-.osg-icon {
+.osg-icons {
   vertical-align: bottom;
 
   @each $name, $content in $sizes {

--- a/src/general/icons/icons.scss
+++ b/src/general/icons/icons.scss
@@ -90,7 +90,7 @@ $sizes: (
   ),
 );
 
-.osg-icons {
+.osg-icon {
   vertical-align: bottom;
 
   @each $name, $content in $sizes {

--- a/src/getting_started/contribute/examples/component/component.html
+++ b/src/getting_started/contribute/examples/component/component.html
@@ -65,7 +65,7 @@
                   <div class="osg-example-component__content">
                     <h3 class="osg-example-component__heading">
                       <!-- Adding an icon as custom content -->
-                      <span class="osg-icon osg-icon-space-right osg-icons--user"></span>
+                      <span class="osg-icon osg-icon-space-right osg-icon--user"></span>
                       Jon Snow
                     </h3>
                     <p class="osg-example-component__text">

--- a/src/pages/oslo/district_selector/district_selector.html
+++ b/src/pages/oslo/district_selector/district_selector.html
@@ -32,7 +32,7 @@
               <div class="osg-grid__column--12">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
                   <button class="osg-button osg-none-breakpoint-medium">
-                    <span class="osg-button__icon osg-icons--crane"></span>
+                    <span class="osg-button__icon osg-icon--crane"></span>
                   </button>
                 </div>
               </div>
@@ -52,8 +52,8 @@
               </div>
               <div class="osg-grid__column--7">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
-                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icons--fire-emblem"></span></button>
-                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icons--crane"></span></button>
+                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icon--fire-emblem"></span></button>
+                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icon--crane"></span></button>
                 </div>
               </div>
             </div>

--- a/src/pages/oslo/employee_search/employee_search.html
+++ b/src/pages/oslo/employee_search/employee_search.html
@@ -31,7 +31,7 @@
               <div class="osg-grid__column--12">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
                   <button class="osg-button osg-none-breakpoint-medium">
-                    <span class="osg-button__icon osg-icons--crane"></span>
+                    <span class="osg-button__icon osg-icon--crane"></span>
                   </button>
                 </div>
               </div>
@@ -51,8 +51,8 @@
               </div>
               <div class="osg-grid__column--7">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
-                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icons--fire-emblem"></span></button>
-                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icons--crane"></span></button>
+                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icon--fire-emblem"></span></button>
+                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icon--crane"></span></button>
                 </div>
               </div>
             </div>

--- a/src/pages/oslo/filter/kindergarten/kindergarten.html
+++ b/src/pages/oslo/filter/kindergarten/kindergarten.html
@@ -31,7 +31,7 @@
               <div class="osg-grid__column--12">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
                   <button class="osg-button osg-none-breakpoint-medium">
-                    <span class="osg-button__icon osg-icons--crane"></span>
+                    <span class="osg-button__icon osg-icon--crane"></span>
                   </button>
                 </div>
               </div>
@@ -51,8 +51,8 @@
               </div>
               <div class="osg-grid__column--7">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
-                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icons--fire-emblem"></span></button>
-                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icons--crane"></span></button>
+                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icon--fire-emblem"></span></button>
+                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icon--crane"></span></button>
                 </div>
               </div>
             </div>
@@ -97,7 +97,7 @@
                               </div>
                             </a>
                             <div class="osg-portrait-card__actions">
-                              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icons--plus-circle"></span>Legg til</button>
+                              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icon--plus-circle"></span>Legg til</button>
                             </div>
                           </div>
                         </div>
@@ -116,7 +116,7 @@
                               </div>
                             </a>
                             <div class="osg-portrait-card__actions">
-                              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icons--minus-circle"></span>Fjern</button>
+                              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icon--minus-circle"></span>Fjern</button>
                             </div>
                           </div>
                         </div>
@@ -134,7 +134,7 @@
                               </div>
                             </a>
                             <div class="osg-portrait-card__actions">
-                              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icons--plus-circle"></span>Legg til</button>
+                              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icon--plus-circle"></span>Legg til</button>
                             </div>
                           </div>
                         </div>
@@ -152,7 +152,7 @@
                               </div>
                             </a>
                             <div class="osg-portrait-card__actions">
-                              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icons--plus-circle"></span>Legg til</button>
+                              <button class="osg-button osg-button--text osg-button--small osg-button--icon-large"><span class="osg-button__icon osg-button__icon--left osg-icon--plus-circle"></span>Legg til</button>
                             </div>
                           </div>
                         </div>

--- a/src/pages/oslo/filter/landscape/landscape.html
+++ b/src/pages/oslo/filter/landscape/landscape.html
@@ -31,7 +31,7 @@
               <div class="osg-grid__column--12">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
                   <button class="osg-button osg-none-breakpoint-medium">
-                    <span class="osg-button__icon osg-icons--crane"></span>
+                    <span class="osg-button__icon osg-icon--crane"></span>
                   </button>
                 </div>
               </div>
@@ -51,8 +51,8 @@
               </div>
               <div class="osg-grid__column--7">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
-                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icons--fire-emblem"></span></button>
-                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icons--crane"></span></button>
+                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icon--fire-emblem"></span></button>
+                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icon--crane"></span></button>
                 </div>
               </div>
             </div>
@@ -89,7 +89,7 @@
                               </div>
                             </a>
                             <div class="osg-portrait-card__actions">
-                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icons--download"></span>BSA23092021.pdf</a>
+                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--download"></span>BSA23092021.pdf</a>
                             </div>
                           </div>
                         </div>
@@ -102,7 +102,7 @@
                               </div>
                             </a>
                             <div class="osg-portrait-card__actions">
-                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icons--download"></span>BSA23092021.pdf</a>
+                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--download"></span>BSA23092021.pdf</a>
                             </div>
                           </div>
                         </div>
@@ -115,7 +115,7 @@
                               </div>
                             </a>
                             <div class="osg-portrait-card__actions">
-                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icons--download"></span>BSA23092021.pdf</a>
+                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--download"></span>BSA23092021.pdf</a>
                             </div>
                           </div>
                         </div>
@@ -128,7 +128,7 @@
                               </div>
                             </a>
                             <div class="osg-portrait-card__actions">
-                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icons--download"></span>BGO23092021.pdf</a>
+                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--download"></span>BGO23092021.pdf</a>
                             </div>
                           </div>
                         </div>
@@ -141,7 +141,7 @@
                               </div>
                             </a>
                             <div class="osg-portrait-card__actions">
-                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icons--download"></span>BGO23092021.pdf</a>
+                              <a href="javascript:void(0)" class="osg-link"><span class="osg-icon osg-icon--space-right osg-icon--download"></span>BGO23092021.pdf</a>
                             </div>
                           </div>
                         </div>

--- a/src/pages/oslo/filter/portrait/portait.html
+++ b/src/pages/oslo/filter/portrait/portait.html
@@ -31,7 +31,7 @@
               <div class="osg-grid__column--12">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
                   <button class="osg-button osg-none-breakpoint-medium">
-                    <span class="osg-button__icon osg-icons--crane"></span>
+                    <span class="osg-button__icon osg-icon--crane"></span>
                   </button>
                 </div>
               </div>
@@ -51,8 +51,8 @@
               </div>
               <div class="osg-grid__column--7">
                 <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
-                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icons--fire-emblem"></span></button>
-                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icons--crane"></span></button>
+                  <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icon--fire-emblem"></span></button>
+                  <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icon--crane"></span></button>
                 </div>
               </div>
             </div>
@@ -71,8 +71,8 @@
               <p class="osg-paragraph">Curabitur porttitor, metus et tempor lacinia, est justo condimentum orci, vitae pharetra ipsum urna ac augue.</p>
             </div>
             <div class="osg-grid__column--12 osg-margin-vertical-20">
-              <button class="osg-button osg-button--small osg-margin-right-15"><span class="osg-button__icon osg-icons--grid"></span><span class="osg-sr-only">Rutenettvising</span></button>
-              <button class="osg-button osg-button--small osg-button--outline osg-margin-right-15"><span class="osg-button__icon osg-icons--map"></span><span class="osg-sr-only">Kartvisning</span></button>
+              <button class="osg-button osg-button--small osg-margin-right-15"><span class="osg-button__icon osg-icon--grid"></span><span class="osg-sr-only">Rutenettvising</span></button>
+              <button class="osg-button osg-button--small osg-button--outline osg-margin-right-15"><span class="osg-button__icon osg-icon--map"></span><span class="osg-sr-only">Kartvisning</span></button>
               <span class="osg-heading-4">123 treff av 123 byggeprosjekter</span>
             </div>
 

--- a/src/pages/oslo/start/start.html
+++ b/src/pages/oslo/start/start.html
@@ -32,7 +32,7 @@
                 <div class="osg-grid__column--12">
                   <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
                     <button class="osg-button osg-none-breakpoint-medium">
-                      <span class="osg-button__icon osg-icons--crane"></span>
+                      <span class="osg-button__icon osg-icon--crane"></span>
                     </button>
                   </div>
                 </div>
@@ -52,8 +52,8 @@
                 </div>
                 <div class="osg-grid__column--7">
                   <div class="osg-full-height osg-flex osg-flex-justify-content-flex-end osg-flex-align-items-center">
-                    <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icons--fire-emblem"></span></button>
-                    <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icons--crane"></span></button>
+                    <button class="osg-button osg-button--outline osg-margin-right-15-breakpoint-medium osg-margin-right-30-breakpoint-large">Button<span class="osg-button__icon osg-button__icon--right osg-icon--fire-emblem"></span></button>
+                    <button class="osg-button osg-button--outline">Button<span class="osg-button__icon osg-button__icon--right osg-icon--crane"></span></button>
                   </div>
                 </div>
               </div>
@@ -87,7 +87,7 @@
                         <p>Viktig melding - fredag 12. september, 13:37</p>
                       </div>
                       <div class="osg-alert__status" aria-label="Important alert">
-                        <span class="osg-icon osg-icons--exclamation-mark-square osg-text-1" aria-label="Important alert"></span>
+                        <span class="osg-icon osg-icon--exclamation-mark-square osg-text-1" aria-label="Important alert"></span>
                       </div>
                     </a>
                   </article>
@@ -148,7 +148,7 @@
                         <div class="osg-grid__column--stack osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
                           <a class="osg-service-link" href="javascript:void(0)">
                             <div class="osg-service-link__icon">
-                              <span class="osg-icon osg-icons--crane" aria-hidden="true"></span>
+                              <span class="osg-icon osg-icon--crane" aria-hidden="true"></span>
                             </div>
                             <div class="osg-service-link__content">
                               <h4 class="osg-service-link__heading">Title enim maximus a</h4>
@@ -159,7 +159,7 @@
                         <div class="osg-grid__column--stack osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
                           <a class="osg-service-link" href="javascript:void(0)">
                             <div class="osg-service-link__icon">
-                              <span class="osg-icon osg-icons--bus" aria-hidden="true"></span>
+                              <span class="osg-icon osg-icon--bus" aria-hidden="true"></span>
                             </div>
                             <div class="osg-service-link__content">
                               <h4 class="osg-service-link__heading">Title enim maximus a</h4>
@@ -170,7 +170,7 @@
                         <div class="osg-grid__column--stack osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
                           <a class="osg-service-link" href="javascript:void(0)">
                             <div class="osg-service-link__icon">
-                              <span class="osg-icon osg-icons--backpack" aria-hidden="true"></span>
+                              <span class="osg-icon osg-icon--backpack" aria-hidden="true"></span>
                             </div>
                             <div class="osg-service-link__content">
                               <h4 class="osg-service-link__heading">Title enim maximus a</h4>
@@ -183,7 +183,7 @@
                         <div class="osg-grid__column--stack osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
                           <a class="osg-service-link" href="javascript:void(0)">
                             <div class="osg-service-link__icon">
-                              <span class="osg-icon osg-icons--coin-stacks" aria-hidden="true"></span>
+                              <span class="osg-icon osg-icon--coin-stacks" aria-hidden="true"></span>
                             </div>
                             <div class="osg-service-link__content">
                               <h4 class="osg-service-link__heading">Title enim maximus a</h4>
@@ -194,7 +194,7 @@
                         <div class="osg-grid__column--stack osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
                           <a class="osg-service-link" href="javascript:void(0)">
                             <div class="osg-service-link__icon">
-                              <span class="osg-icon osg-icons--heart-plus" aria-hidden="true"></span>
+                              <span class="osg-icon osg-icon--heart-plus" aria-hidden="true"></span>
                             </div>
                             <div class="osg-service-link__content">
                               <h4 class="osg-service-link__heading">Title enim maximus a</h4>
@@ -205,7 +205,7 @@
                         <div class="osg-grid__column--stack osg-grid__column--12 osg-grid__column--4-breakpoint-medium">
                           <a class="osg-service-link" href="javascript:void(0)">
                             <div class="osg-service-link__icon">
-                              <span class="osg-icon osg-icons--chevron-right" aria-hidden="true"></span>
+                              <span class="osg-icon osg-icon--chevron-right" aria-hidden="true"></span>
                             </div>
                             <div class="osg-service-link__content">
                               <h4 class="osg-service-link__heading">Title enim maximus a</h4>


### PR DESCRIPTION
Dette er en del av
https://trello.com/c/ZfVFqJTB/657-overskrift-i-search-seasons-m%C3%A5-oppdateres-med-nye-class-names-og-fix-flere-ikoner-klass

viser ikke tekst etter merge til test.