### PR TITLE
Io 811 - Fix wrong icon size and text in status messages

### DIFF
--- a/src/components/status_message/status_message.scss
+++ b/src/components/status_message/status_message.scss
@@ -14,7 +14,6 @@
   word-break: break-word;
 
   &__heading {
-    @extend %osg-text--size-juliett;
     @extend %osg-text--weight-medium;
     @extend %osg-margin-bottom-4;
     display: inline-block;
@@ -51,7 +50,7 @@
   }
 
   &__icon {
-    @extend %osg-icon--size-kilo, %osg-icon--size-juliett-breakpoint-medium;
+    @extend %osg-icon--size-kilo, %osg-icon--size-juliett-breakpoint-large;
     @extend %osg-padding-right-2;
 
     line-height: 1.5rem;


### PR DESCRIPTION
Heading tekst hadde feil størrelse og tykkelse på medium og små.
Ikoner hadde feil størrelse på medium 

![Screenshot 2023-03-03 at 11 21 30](https://user-images.githubusercontent.com/37497176/222695716-2acfb1ed-fa0e-4a73-961e-cfdf9d743d08.png)
